### PR TITLE
app.eventNotifier link is not working

### DIFF
--- a/src/pages/ps_reference/media/advanced/event-listener.md
+++ b/src/pages/ps_reference/media/advanced/event-listener.md
@@ -8,7 +8,7 @@ sidebar_label: "Event Listeners"
 
 Photoshop emits various event notifications when a user is actively interacting with the application.
 
-During development of your plugin, you can use [app.eventNotifier](../../classes/photoshop/#eventnotifier) to enumerate all the event types you'd like to be notified about.
+During development of your plugin, you can use [app.eventNotifier](../../../classes/photoshop/#eventnotifier) to enumerate all the event types you'd like to be notified about.
 
 In a production environment, this 'catch-all' notifier is unavailable to you. Once you've created a list of key events you'd like to be notified of, use the following action API to register a listener:
 


### PR DESCRIPTION
## Description

app.eventNotifier link is not working
Points to https://www.adobe.io/photoshop/uxp/ps_reference/media/classes/photoshop/#eventnotifier and `/media` part shouldn't be there. I think it's how `.md` file is the last part of URL and the link gets messed up. It doesn't match the folder/file structure.

## Related Issue
#139 

## Motivation and Context
Fixes the link

## How Has This Been Tested?
Counted folders :)

## Screenshots (if appropriate):


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
