### PR TITLE
Update manifest docs to offer better clarity for the host key

### DIFF
--- a/src/pages/guides/uxp_guide/uxp-misc/manifest-v4/index.md
+++ b/src/pages/guides/uxp_guide/uxp-misc/manifest-v4/index.md
@@ -66,9 +66,9 @@ Key path | Type | Description | Required
 `name`   | `string` | The name should be 3 - 45 characters. We recommend your plugin name matches the _project name_ you created when getting your plugin ID from the Adobe Developer Console. | Develop / Publish
 `version`| `string` | Version number of your plugin in `x.y.z` format. <br/>Version must be three segments and each version component must be between `0` and `99`. | Develop / Publish
 `main`   | `string` | Path to the your plugin initialization code. This can be a JavaScript file or an HTML file. | Optional (defaults to `main.js`)
-`icons` | `array<IconDefinition>` | Icons for your plugin (which may be rendered in various contexts, such as the plugin panel) <br/> PNG, JPG/JPEG formats are supported and the max file size for each icon is 1MB. <br/> You should specify at least the 1x and 2x size. Icons for the Plugin Manager are uploaded directly via the Adobe Developer Console, not included within your plugin itself. See our ["Publishing your plugin" guide](../../../../distribution/packaging-your-plugin/) to learn more. | Publish
-| `host` | `array<HostDefinition>` | Describes the supported applications that can be used with this plugin. This can include the type of application, the minimum required version, or the maximum version of the host app that the plugin supports.  | Develop / Publish
-`entryPoints` | `array<EntryPointDefinition>`| Describes the entries your plugin adds to the _Plugins_ menu & plugin panel. See the next section for details. | Develop / Publish
+`icons` | `IconDefinition[]` | Icons for your plugin (which may be rendered in various contexts, such as the plugin panel) <br/> PNG, JPG/JPEG formats are supported and the max file size for each icon is 1MB. <br/> You should specify at least the 1x and 2x size. Icons for the Plugin Manager are uploaded directly via the Adobe Developer Console, not included within your plugin itself. See our ["Publishing your plugin" guide](../../../../distribution/packaging-your-plugin/) to learn more. | Publish
+| `host` | `HostDefinition\|HostDefinition[]` | Describes the supported applications that can be used with this plugin. This can include the type of application, the minimum required version, or the maximum version of the host app that the plugin supports. <br/><br/> **Note:** An array can ONLY be used during development. A single definition will be needed when submitting to the marketplace | Develop / Publish
+`entryPoints` | `EntryPointDefinition[]`| Describes the entries your plugin adds to the _Plugins_ menu & plugin panel. See the next section for details. | Develop / Publish
 
 ## Icons
 
@@ -86,9 +86,9 @@ Key | Type | Description
 `theme` | `string[]` | Array of themes this icon supports. Photoshop supports `lightest`, `light`, `dark`, and `darkest`. If all themes are compatible with the icon, you can use `all`. (Default is `all`).
 `species` | `string[]` | Identifies the type of icon and where it would make sense to display it. The default is `generic`, meaning that Photoshop is free to use this icon anywhere.
 
-## Hosts
+## Host
 
-The `host` field is an _array_ of objects matching the `HostDefinition` format specified below. These entries allow your plugin to be ran on multiple apps such as Adobe XD or Photoshop. Optionally, the field can contain a HostDefinition instead of a full array if only one type of app is being supported.
+The `host` field is an _object_ matching the `HostDefinition` format specified below. This entry allows your plugin to specify which app your plugin can run on such as Adobe XD or Photoshop. During development, the field can contain an _array_ of HostDefinition's. This can be very convient during development of cross-compatible UXP plugins. However, during submission to the marketplace, only one HostDefinition is allowed.
 
 ### HostDefinition
 

--- a/src/pages/guides/uxp_guide/uxp-misc/manifest-v4/index.md
+++ b/src/pages/guides/uxp_guide/uxp-misc/manifest-v4/index.md
@@ -66,16 +66,16 @@ Key path | Type | Description | Required
 `name`   | `string` | The name should be 3 - 45 characters. We recommend your plugin name matches the _project name_ you created when getting your plugin ID from the Adobe Developer Console. | Develop / Publish
 `version`| `string` | Version number of your plugin in `x.y.z` format. <br/>Version must be three segments and each version component must be between `0` and `99`. | Develop / Publish
 `main`   | `string` | Path to the your plugin initialization code. This can be a JavaScript file or an HTML file. | Optional (defaults to `main.js`)
-`icons` | `array<object>` | Icons for your plugin (which may be rendered in various contexts, such as the plugin panel) <br/> PNG, JPG/JPEG formats are supported and the max file size for each icon is 1MB. <br/> You should specify at least the 1x and 2x size. Icons for the Plugin Manager are uploaded directly via the Adobe Developer Console, not included within your plugin itself. See our ["Publishing your plugin" guide](../../../../distribution/packaging-your-plugin/) to learn more. | Publish
-`host.app` | `string` | Indicates that this is a plugin for an Adobe app (currently, the only valid values here are `XD` or `PS`). | Develop / Publish
-`host.minVersion` | `string` | Minimum required version of the host app (in `x.y` format) that can run this plugin. The lowest valid version for Photoshop plugins is `22.0`. <br/>**Note:** The version number must be at least two segments. Typically, you'll leave the minor segment set to `0`, e.g. `22.0`. | Develop / Publish
-`host.maxVersion` | `string` | Maximum version of host app that can run this plugin. Same formatting as `host.minVersion`. | Optional
-`entryPoints` | `EntryPointDefinition]`| Describes the entries your plugin adds to the _Plugins_ menu & plugin panel. See the next section for details. | Develop / Publish
+`icons` | `array<IconDefinition>` | Icons for your plugin (which may be rendered in various contexts, such as the plugin panel) <br/> PNG, JPG/JPEG formats are supported and the max file size for each icon is 1MB. <br/> You should specify at least the 1x and 2x size. Icons for the Plugin Manager are uploaded directly via the Adobe Developer Console, not included within your plugin itself. See our ["Publishing your plugin" guide](../../../../distribution/packaging-your-plugin/) to learn more. | Publish
+| `host` | `array<HostDefinition>` | Describes the supported applications that can be used with this plugin. This can include the type of application, the minimum required version, or the maximum version of the host app that the plugin supports.  | Develop / Publish
+`entryPoints` | `array<EntryPointDefinition>`| Describes the entries your plugin adds to the _Plugins_ menu & plugin panel. See the next section for details. | Develop / Publish
 
 ## Icons
 
 Icons are not required during development, but *must be provided* when distributing through the Plugin Marketplace.
-The `icons` field is an array of a `IconDefinition`s:
+The `icons` field is an array of a `IconDefinition`s.
+
+### IconDefinition
 
 Key | Type | Description
 ----|------|----------------
@@ -86,9 +86,21 @@ Key | Type | Description
 `theme` | `string[]` | Array of themes this icon supports. Photoshop supports `lightest`, `light`, `dark`, and `darkest`. If all themes are compatible with the icon, you can use `all`. (Default is `all`).
 `species` | `string[]` | Identifies the type of icon and where it would make sense to display it. The default is `generic`, meaning that Photoshop is free to use this icon anywhere.
 
+## Hosts
+
+The `host` field is an _array_ of objects matching the `HostDefinition` format specified below. These entries allow your plugin to be ran on multiple apps such as Adobe XD or Photoshop. Optionally, the field can contain a HostDefinition instead of a full array if only one type of app is being supported.
+
+### HostDefinition
+
+Key | Type | Description | Required
+----|------|-------------| --------
+`app` | `string` | Indicates the supported application for this plugin (currently, the only valid values here are `"XD"` and `"PS"`). | Develop / Publish
+`minVersion` | `string` | Minimum required version of the host app (in `x.y` format) that can run this plugin. The lowest valid version for manifest V4 plugins is version `22.0`. <br/> **Note:** The version number must be at least two segments. Typically, you'll leave the minor segment set to `0`, e.g. `22.0`. | Develop / Publish
+`maxVersion` | `string` | Maximum version of host app that can run this plugin. Same formatting as `host.minVersion`. | Optional
+
 ## Entry Points
 
-The `entryPoints` field is an _array_ of objects matching the EntryPointDefinition format specified below. These entries appear both in the _Plugins_ menu in the native menubar, and the plugin panel.
+The `entryPoints` field is an _array_ of objects matching the `EntryPointDefinition` format specified below. These entries appear both in the _Plugins_ menu in the native menubar, and the plugin panel.
 
 Each entry point specifies a `type`, to create either a direct-action command or a panel show/hide command.
 


### PR DESCRIPTION
## Description

The changes to the manifest documentation aim to make the `host` key clearer in terms of the types of values that it accepts. Currently, there is no written documentation that the key can accept an array of objects. This allows for the ability to create a plugin that is compatible across multiple apps. This is solved with the introduction of the `HostDefinition` object which describes the details on the various applications a plugin can support.

In addition, a few more changes were made to increase the overall consistency of the documentation. These changes include specifying the type of array the `icons` key accepts as well as adding a header and tweaking the styling of the `Entry Points` section