### PR TITLE
adjust to host versions of docs in the same domain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ on:
       excludeSubfolder:
         description: 'Exclude a subfolder from deletion'
         required: false
-        default: ''
+        default: '2021, 2023'
 jobs:
   set-state:
     runs-on: ubuntu-latest

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -15,11 +15,12 @@ module.exports = {
     versions: [
       {
         title: '2022',
+        path: '/photoshop/uxp/',
         selected: true
       },
       {
         title: '2021',
-        path: 'https://developer-stage.adobe.com/photoshop/uxp/2021'
+        path: '/photoshop/uxp/2021/'
       }
     ],
     pages: [
@@ -258,5 +259,5 @@ module.exports = {
     ],
   },
   plugins: [`@adobe/gatsby-theme-aio`],
-  pathPrefix: process.env.PATH_PREFIX || "/photoshop/uxp/2022/",
+  pathPrefix: process.env.PATH_PREFIX || "/photoshop/uxp/",
 };


### PR DESCRIPTION
## Description

adjust to host versions of docs in the same domain

## Related Issue

https://jira.corp.adobe.com/browse/PS-91383 docs should be same domain and generally should have relative paths (don't require a domain within the project generally)

## Motivation and Context

same domain, don't link to other environments

## How Has This Been Tested?

intent to test on staging before deploying to production

## Types of changes

config environment deployment related change:
NOTE relates directly to PR for 2021 docs at https://github.com/AdobeDocs/uxp-photoshop-2021/pull/19

## Checklist:

- [ x ] My code follows the code style of this project.
