### PR TITLE
Modify manifest v5 documentation to include entrypoints.setup() updates

### DIFF
--- a/src/pages/guides/uxp_guide/uxp-misc/manifest-v5/index.md
+++ b/src/pages/guides/uxp_guide/uxp-misc/manifest-v5/index.md
@@ -90,6 +90,81 @@ Key path | Type | Description | Change
 `requiredPermissions` | object | Declare [plugin permissions](#plugin-permissions). | New in v5.
 `entrypoints` | `EntryPointDefinition[]` | Describes the entries your plugin adds to the _Plugins_ menu and plugin panel. | v5 changes in next section.
 
+## Updates to Entrypoints methods
+With manifest v4: 
+* Promise-based methods were not supported for entrypoint methods. 
+* No timeouts for entrypoints methods.
+* All panel entrypoints have only one argument `event` which contains `node`, `panel`, `eventName` and `PanelID`.
+
+Manifest v5 brings additional lifecycle events to better manage your plugin and more flexibility in specifying the initial view and location of plugins' panels: 
+* UXP honors promises returned by (most) entrypoint methods. 
+  * **Plugin entrypoints**: Promise support is enabled for plugin `destroy`. 
+  * **Panel entrypoints**: Promise support is enabled for panel `create`, `show`, `destroy`, `hide`. 
+  * Currently, panel `show` is tied to plugin `create`, and panel `hide` is tied to plugin `destroy`.
+* Entrypoint methods have a timeout of 300 milliseconds
+* Panel entrypoints have `rootNode` as first argument and `data` as second argument for `show` and `hide`.
+  
+### entrypoints.setup() using promises
+```js
+import { entrypoints } from "uxp";
+entrypoints.setup({
+    plugin: {
+        create() {
+            console.log("Plugin has been loaded, plugin.create has been triggered.");
+        },
+        destroy() {
+            return new Promise(function (resolve, reject) {
+                console.log("Plugin has been loaded, plugin.create has been triggered.");
+                resolve();
+            });
+        }
+    },
+    panels: {
+        panelA: {
+            create(rootNode) {
+                return new Promise(function (resolve, reject) {
+                    console.log("PanelA is created, panelA.create has been triggered.");
+                    resolve();
+                });
+            },
+            show(rootNode, data) {
+                return new Promise(function (resolve, reject) {
+                    console.log("PanelA is about to be displayed,  panelA.show has been triggered with data ", data);
+                    resolve();
+                });
+            },
+            hide(rootNode, data) {
+                return new Promise(function (resolve, reject) {
+                    console.log("PanelA is about to be hidden,  panelA.hide has been triggered with data ", data);
+                    resolve();
+                });
+            },
+            destroy(rootNode) {
+                return new Promise(function (resolve, reject) {
+                    console.log("PanelA is about to be destroyed,  panelA.destroy has been triggered.");
+                    resolve();
+                });
+            },
+            invokeMenu(menuId) {
+                return new Promise(function (resolve, reject) {
+                    console.log("A menu item on PanelA has been invoked,  panelA.invokeMenu has been triggered with menu id ", menuId);
+                    resolve();
+                });
+            },
+            menuItems: [...]
+        },
+        "panelB": {..}
+    },
+    commands: {
+        "command1": {
+            run() {..},
+            cancel() {..}
+        },
+        "command2": function(){..}
+    }
+});
+```
+
 ## Plugin Permissions
 Plugins using Manifest v5 will enjoy the enhancements in security with the introduction of new permissions model. Users will be asked for their consent when your plugin attempts to use `openExternal`, `openPath`, and `sp-link`/anchor tags. For everything else, consent is given at install time.
 


### PR DESCRIPTION
Added an "updates to entrypoints" section corresponding with manifest v5 changes to entrypoints.setup() 

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
