### PR TITLE
Table of Contents mismatch.

### DIFF
--- a/src/pages/guides/uxp_guide/uxp-misc/index.md
+++ b/src/pages/guides/uxp_guide/uxp-misc/index.md
@@ -17,7 +17,7 @@ description:
 
 UXP is a growing technology platform and, as such, has many different facets. Here are topics you may need to know to successfully create a UXP plugin:
 
-* [The UXP Manifest](./manifest-v4/)
+* [The UXP Toolchain](./uxp-toolchain/)
 * [Localization and Platforms](./localization-and-platforms/)
 * [Flyout Menus](./flyout-menus/)
 * [File Access](./file-access/)


### PR DESCRIPTION
## Description

The first bullet item on this page (The UXP Manifest) did not match the first item (The UXP Toolchain) listed under the "Other Topics" table of contents in gatsby-config.js.

Note: "The UXP Manifest" is already present in the table of contents as its own item linking to (./manifest-v4).

https://github.com/AdobeDocs/uxp-photoshop/blob/3864217bbc5b57707000e4892f4b09c312bdb6e2/gatsby-config.js#L81 https://github.com/AdobeDocs/uxp-photoshop/blob/3864217bbc5b57707000e4892f4b09c312bdb6e2/gatsby-config.js#L183

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
