### PR TITLE
Update Ps UXP DOM API for Guides and ColorSamplers

### DIFF
--- a/reference-ps.js
+++ b/reference-ps.js
@@ -16,6 +16,10 @@ module.exports = [{
 			"path": "/ps_reference/classes/channel/"
 		},
 		{
+			"title": "ColorSampler",
+			"path": "/ps_reference/classes/colorsampler/"
+		},
+		{
 			"title": "Document",
 			"path": "/ps_reference/classes/document/"
 		},
@@ -50,6 +54,10 @@ module.exports = [{
 		{
 			"title": "Channels",
 			"path": "/ps_reference/classes/channels/"
+		},
+		{
+			"title": "ColorSamplers",
+			"path": "/ps_reference/classes/colorsamplers/"
 		},
 		{
 			"title": "Documents",

--- a/src/pages/ps_reference/changelog/index.md
+++ b/src/pages/ps_reference/changelog/index.md
@@ -6,9 +6,31 @@ description: Contains a running log of changes to the UXP API environment in Ado
 
 # Photoshop API Changelog
 
-## Photoshop 24.0 (October 2022)
+## Photoshop Beta (24.0 October 2022)
 
-## Photoshop Beta
+### ColorSamplers support
+
+The ColorSampler DOM API is now available in Photoshop.
+
+- The [ColorSamplers collection](../classes/colorsamplers/) behaves like other collections at the Document level in the API. ColorSamplers further supports the following methods:
+    - `colorSamplers.add()` 
+    - `colorSamplers.removeAll()`
+- The [ColorSamplers class](../classes/colorsampler) implements the following properties and methods: 
+    - `typename`: String
+    - `parent`: [Document](../classes/document)
+    - `position`: `{x: number, y: number}`
+    - `color`: [SolidColor](../classes/solidcolor.md)
+	- `move({x: number, y: number})`
+	- `remove()`
+	<!-- - `sampleSize()`: static member, accepts values from [Constants.SampleSize](../modules/constants/#samplesize). -->
+- The [Document](../classes/document#samplecolor) class implements a new `sampleColor()` method that samples an `{x, y}` position on the fly, returning a [SolidColor](../classes/solidcolor.md) object without the need to create a [ColorSampler](../classes/colorsampler.md) object.
+
+### Guide fixes
+
+- [Guide.coordinate](../classes/guide/#coordinate) Fixes coordinate getter when document resolution is not 72 PPI
+- [Guide.coordinate](../classes/guide/#coordinate) Fixes coordinate setter when document resolution is not 72 PPI
+- [Guides.add](../classes/guides/#add) Fixes coordinate when creating a new guide if document resolution is not 72 PPI
+- [Guides.add](../classes/guides/#add) Creating a new guide had returned an invalid, nonexistent instance. It now points to an existing guide.
 
 ### Known Issues and Workarounds
 - A new page of [Known Issues and Workarounds](../known-issues) was introduced, and aims to outline some common issues encountered by our developer community. New entries will be summarized in this changelog.
@@ -25,6 +47,7 @@ description: Contains a running log of changes to the UXP API environment in Ado
 - Color mode validation for all filters
 - Fixed Lens Flare coordinates
 - Fixed file arguments for filters 
+
 
 ## Photoshop 23.5 (August 2022)
 

--- a/src/pages/ps_reference/classes/colorsampler.md
+++ b/src/pages/ps_reference/classes/colorsampler.md
@@ -1,0 +1,85 @@
+---
+id: "colorsampler"
+title: "ColorSampler"
+sidebar_label: "ColorSampler"
+repo: "uxp-photoshop"
+product: "photoshop"
+keywords:
+  - Creative Cloud
+  - API Documentation
+  - UXP
+  - Plugins
+  - JavaScript
+  - ExtendScript
+  - SDK
+  - C++
+  - Scripting
+---
+
+# ColorSampler
+
+Represents a ColorSampler object in the Photoshop DOM.
+
+ColorSamplers are created through the [ColorSamplers](/ps_reference/classes/colorsamplers/) collection via the [ColorSamplers.add](/ps_reference/classes/colorsamplers/#add) method:
+
+```javascript
+const app = require("photoshop").app;
+app.activeDocument.colorSamplers.add({x: 100, y: 100});
+```
+
+Properties such as `color`, `position` and `parent` document can be then accessed on the ColorSampler instance:
+
+```javascript
+let cs = app.activeDocument.colorSamplers[0];
+console.log(cs.position);  // {x: 100, y: 100}
+console.log(cs.color.rgb); // SolidColor {red: 0, green: 255, blue: 0}
+console.log(cs.parent);    // Document
+```
+
+An existing ColorSampler instance can be moved to a different position:
+
+```javascript
+cs.move({x: 200, y: 200});
+console.log(cs.position);  // {x: 200, y: 200}
+```
+
+Or removed altogether from the document:
+
+```javascript
+cs.remove();
+console.log(app.activeDocument.colorSamplers.length); // 0
+```
+
+## Properties
+
+| Name | Type | Access | Description |
+| :------ | :------ | :------ | :------ |
+| color | [*SolidColor*](/ps_reference/classes/solidcolor/) \| [*NoColor*](/ps_reference/colors/nocolor/) | Read-only | The color reading of this ColorSampler in its current position |
+| docId | *number* | Read-only | The ID of the Document of this ColorSampler. |
+| parent | [*Document*](/ps_reference/classes/document/) | Read-only | Owner document of this ColorSampler |
+| position | *object* | Read-only | The position of this ColorSampler |
+| typename | *string* | Read-only | The class name of the referenced ColorSampler object |
+
+## Methods
+
+### move
+
+*void*
+
+Moves the ColorSampler object to the given position
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `position` | *object* | Object literal with target coordinates in pixels `{x: number, y: number}`. |
+| `position.x` | *number* | - |
+| `position.y` | *number* | - |
+
+___
+
+### remove
+
+*void*
+
+Deletes the given ColorSampler object

--- a/src/pages/ps_reference/classes/colorsamplers.md
+++ b/src/pages/ps_reference/classes/colorsamplers.md
@@ -1,0 +1,92 @@
+---
+id: "colorsamplers"
+title: "ColorSamplers"
+sidebar_label: "ColorSamplers"
+repo: "uxp-photoshop"
+product: "photoshop"
+keywords:
+  - Creative Cloud
+  - API Documentation
+  - UXP
+  - Plugins
+  - JavaScript
+  - ExtendScript
+  - SDK
+  - C++
+  - Scripting
+---
+
+# ColorSamplers
+
+A collections class allowing for array access into a document's ColorSamplers
+
+Access this collection through the [Document.colorSamplers](/ps_reference/classes/document/#colorsamplers) property. For instance,
+the following adds a new colorSampler to the collection:
+
+```javascript
+const app = require("photoshop").app;
+app.activeDocument.colorSamplers.add({x: 20, y: 20});
+```
+
+A colorSampler can be access through the collection's `[index]` property,
+and then queried for its properties.
+For example, the following gets the first colorSampler in the collection, and then
+unpacks its `color` and `position` properties via a destructuring assignment to get
+the sampled color as a [SolidColor](/ps_reference/classes/solidcolor/) object and its current position as an `{x, y}` object:
+
+```javascript
+const cs = app.activeDocument.colorSamplers[0];
+const { color, position } = cs; // destructuring assignment
+console.log(color.rgb); // returns a SolidColor object:
+                        // {red: 0, green: 255, blue: 0, model: ColorModel.RGB}
+console.log(position); // returns an object: {x: 20, y: 20}
+
+```
+
+To empty the colorSamplers collection, use the `removeAll()` method.
+
+```javascript
+app.activeDocument.colorSamplers.removeAll();
+app.activeDocument.colorSamplers.length; // returns 0
+```
+
+## Properties
+
+| Name | Type | Access | Description |
+| :------ | :------ | :------ | :------ |
+| length | *number* | Read-only | Number of [ColorSampler](/ps_reference/modules/colorsampler/) elements in this collection &#x60;&#x60;&#x60;javascript // A new document starts with no colorSamplers app.activeDocument.colorSamplers.length; // returns 0 &#x60;&#x60;&#x60; |
+| parent | Document | Read-only | The owner [Document](/ps_reference/modules/document/) of this ColorSamplers collection |
+
+## Methods
+
+### add
+
+[*ColorSampler*](/ps_reference/classes/colorsampler/)
+
+Adds a [ColorSampler](/ps_reference/classes/colorsampler/) to the collection at the given `{x, y}` coordinates in pixels
+
+```javascript
+app.activeDocument.colorSamplers.add({x: 20, y: 20});
+app.activeDocument.colorSamplers.length; // returns 1
+```
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `position` | *object* |
+| `position.x` | *number* |
+| `position.y` | *number* |
+
+___
+
+### removeAll
+
+*void*
+
+Removes all ColorSampler instances from this collection
+
+```javascript
+app.activeDocument.colorSamplers.removeAll();
+app.activeDocument.colorSamplers.length; // returns 0
+```

--- a/src/pages/ps_reference/classes/document.md
+++ b/src/pages/ps_reference/classes/document.md
@@ -83,8 +83,9 @@ document.saveAs.psb(entryPsb, { embedColorProfile: true });
 | cloudWorkAreaDirectory | *string* | Read-only | Local directory for this cloud document. |
 | colorProfileName | *string* | Read-write | Name of the color profile.  Valid only when [colorProfileType](/ps_reference/classes/document/#colorprofiletype) is &#x60;CUSTOM&#x60; or &#x60;WORKING&#x60;, returns &quot;None&quot; otherwise |
 | colorProfileType | [*ColorProfileType*](/ps_reference/modules/constants/#colorprofiletype) | Read-write | Whether the document uses the working color profile, a custom profile, or no profile. |
+| colorSamplers | [*ColorSamplers*](/ps_reference/classes/colorsamplers/) | Read-only | The collection of Color Samplers present in the document. |
 | compositeChannels | [*Channel*](/ps_reference/classes/channel/)[] | Read-only | Composite channels in the document. |
-| guides | [*Guides*](/ps_reference/classes/guides/) | Read-only | - |
+| guides | [*Guides*](/ps_reference/classes/guides/) | Read-only | The collection of Guides present in the document. |
 | height | *number* | Read-only | Document&#x27;s height in pixels |
 | histogram | *number*[] | Read-only | A histogram containing the number of pixels at each color intensity level for the composite channel. The array contains 256 members.  Valid only when [mode](/ps_reference/classes/document/#mode) &#x3D; &#x60;DocumentMode.{RGB,CMYK,INDEXEDCOLOR}&#x60; |
 | historyStates | [*HistoryStates*](/ps_reference/classes/historystates/) | Read-only | History states of the document |
@@ -398,6 +399,33 @@ Rotates the image clockwise in given angle, expanding canvas if necessary. (Prev
 | Name | Type |
 | :------ | :------ |
 | `angles` | *number* |
+
+___
+
+### sampleColor
+
+**async** : *Promise*<[*SolidColor*](/ps_reference/classes/solidcolor/) \| [*NoColor*](/ps_reference/colors/nocolor/)\>
+
+Returns a SolidColor object sampled from the document at the given position.
+
+```javascript
+let col = await app.activeDocument.sampleColor({x: 100, y: 100});
+console.log(col.rgb);
+// {
+//    red: 233,
+//    green: 179,
+//    blue: 135,
+//    hexValue: "E9B387"
+// }
+```
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `position` | *object* | The point to sample `{x: number, y: number}`. |
+| `position.x` | *number* | The horizontal coordinate in pixels. |
+| `position.y` | *number* | The vertical coordinate in pixels. |
 
 ___
 

--- a/src/pages/ps_reference/classes/guide.md
+++ b/src/pages/ps_reference/classes/guide.md
@@ -24,7 +24,7 @@ Represents a single guide in the document.
 
 | Name | Type | Access | Description |
 | :------ | :------ | :------ | :------ |
-| coordinate | *number* | Read-write | Location of the guide from origin of image, in float units.  In the future, we will accept a UnitValue here, supporting number input for floatUnit |
+| coordinate | *number* | Read-write | Position of the guide measured from the ruler origin in pixels. The value can be a decimal number.  Note: the user can move the ruler origin which will affect the position value of the guides.  ***Fixes in Photoshop 24.0:***  - *Return correct value when resolution is not 72 PPI* |
 | direction | [*Direction*](/ps_reference/modules/constants/#direction) | Read-write | Indicates whether the guide is vertical or horizontal |
 | docId | *number* | Read-only | The ID of the document of this guide. |
 | id | *number* | Read-only | For use with batchPlay operations. This guide ID, along with its document ID can be used to represent this guide for the lifetime of this document or the guide. |

--- a/src/pages/ps_reference/classes/guides.md
+++ b/src/pages/ps_reference/classes/guides.md
@@ -45,22 +45,27 @@ app.activeDocument.guides.add(Constants.Direction.HORIZONTAL, 20);
 | Name | Type | Access | Description |
 | :------ | :------ | :------ | :------ |
 | length | *number* | Read-only | Number of [Guide](/ps_reference/modules/guide/) elements in this collection |
-| parent | Document | Read-only | The owner document of this Guide collection |
+| parent | [*Document*](/ps_reference/classes/document/) | Read-only | The owner document of this Guide collection |
 
 ## Methods
 
 ### add
 
-*void*
+[*Guide*](/ps_reference/classes/guide/)
 
 Adds a guide for the collection at the given coordinate and direction
 
+***Fixes in Photoshop 24.0:***
+
+- *Corect coordinate when resolution is not 72 PPI*
+- *Returns valid instance of guide*
+
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `direction` | [*Direction*](/ps_reference/modules/constants/#direction) |
-| `coordinate` | *number* |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `direction` | [*Direction*](/ps_reference/modules/constants/#direction) | Indicates whether the guide is vertical or horizontal |
+| `coordinate` | *number* | Position of the guide measured from the ruler origin in pixels. The value can be a decimal number.  Note: the user can move the ruler origin which will affect the position value of the guides. |
 
 ___
 

--- a/src/pages/ps_reference/modules.md
+++ b/src/pages/ps_reference/modules.md
@@ -22,6 +22,7 @@ keywords:
 
 - [Actions](/ps_reference/modules/actions/)
 - [Channel](/ps_reference/modules/channel/)
+- [ColorSampler](/ps_reference/modules/colorsampler/)
 - [Constants](/ps_reference/modules/constants/)
 - [CoreModules](/ps_reference/modules/coremodules/)
 - [Document](/ps_reference/modules/document/)
@@ -34,6 +35,7 @@ keywords:
 - [Photoshop](/ps_reference/modules/photoshop/)
 - [SubPathItem](/ps_reference/modules/subpathitem/)
 - [collections/Channels](/ps_reference/modules/collections/channels/)
+- [collections/ColorSamplers](/ps_reference/modules/collections/colorsamplers/)
 - [collections/Documents](/ps_reference/modules/collections/documents/)
 - [collections/Guides](/ps_reference/modules/collections/guides/)
 - [collections/HistoryStates](/ps_reference/modules/collections/historystates/)

--- a/src/pages/ps_reference/modules/collections/colorsamplers.md
+++ b/src/pages/ps_reference/modules/collections/colorsamplers.md
@@ -1,0 +1,23 @@
+---
+id: "colorsamplers"
+title: "ColorSamplers"
+sidebar_label: "ColorSamplers"
+repo: "uxp-photoshop"
+product: "photoshop"
+keywords:
+  - Creative Cloud
+  - API Documentation
+  - UXP
+  - Plugins
+  - JavaScript
+  - ExtendScript
+  - SDK
+  - C++
+  - Scripting
+---
+
+# collections/ColorSamplers
+
+## Classes
+
+- [ColorSamplers](/ps_reference/classes/colorsamplers/)

--- a/src/pages/ps_reference/modules/colorsampler.md
+++ b/src/pages/ps_reference/modules/colorsampler.md
@@ -1,0 +1,23 @@
+---
+id: "colorsampler"
+title: "ColorSampler"
+sidebar_label: "ColorSampler"
+repo: "uxp-photoshop"
+product: "photoshop"
+keywords:
+  - Creative Cloud
+  - API Documentation
+  - UXP
+  - Plugins
+  - JavaScript
+  - ExtendScript
+  - SDK
+  - C++
+  - Scripting
+---
+
+# ColorSampler
+
+## Classes
+
+- [ColorSampler](/ps_reference/classes/colorsampler/)

--- a/src/pages/ps_reference/modules/constants.md
+++ b/src/pages/ps_reference/modules/constants.md
@@ -678,6 +678,22 @@ Pass to [Layer.applyRipple](/ps_reference/classes/layer/#applyripple)().
 
 ___
 
+### SampleSize
+
+Sample size for the EyeDropper tool and ColorSampler instances.
+
+| Name | Description |
+| :------ | :------ |
+| POINTSAMPLE | - |
+| SAMPLE101X101 | - |
+| SAMPLE11X11 | - |
+| SAMPLE31X31 | - |
+| SAMPLE3X3 | - |
+| SAMPLE51X51 | - |
+| SAMPLE5X5 | - |
+
+___
+
 ### SaveMethod
 
 | Name | Description |


### PR DESCRIPTION
## Description
This round we have an update to Guides and the new addition, ColorSamplers.  Guides received some backend fixes to address incorrect coordinate values when the document resolution was other than 72PPI.  Additionally, support for modified ruler origins was included.  Color Sampler objects and a new Document method `sampleColor` are now available.