### PR TITLE
Updated docs to show that Layer.name is actually a Read/Write property instead of read-only.

### DIFF
--- a/src/pages/ps_reference/classes/layer.md
+++ b/src/pages/ps_reference/classes/layer.md
@@ -50,7 +50,7 @@ group.layers.forEach((layer) => {
 | layers | [*Layers*](/ps_reference/classes/layers/) | R | 23.0 | The layers inside this group layer. |
 | linkedLayers | [*Layers*](/ps_reference/classes/layers/) | R | 22.5 | Layers linked to this layer. See [Layer.link](/ps_reference/classes/layer/#link) |
 | locked | *boolean* | R | 22.5 | True if any property of this layer is locked. |
-| name | *string* | R | 22.5 | Name of the layer. |
+| name | *string* | R W | 22.5 | Name of the layer. |
 | opacity | *number* | R W | 22.5 | The master opacity of the layer, in percent. |
 | parent | [*Layer*](/ps_reference/classes/layer/) | R | 22.5 | The group layer that contains this layer. It will return null if the layer is a top layer in the document. |
 | pixelsLocked | *boolean* | R W | 22.5 | When set to true, prevents the pixels of this layer from being edited. |


### PR DESCRIPTION
## Description

Updated docs to show that `Layer.name` is actually a Read/Write property instead of read-only.

## Motivation and Context

The documentation states that `Layer.name` is a read-only property. However, assigning a value to this property does in fact change the layer name in the PS layers panel.

## Types of changes

- [x] Documentation only
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
