### PR TITLE
Ps executeAsModal page update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "uxp-photoshop-documentation",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -12,7 +12,7 @@
     "gatsby": "4.22.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "uxp-documentation": "git://github.com/adobedocs/uxp#v7.4.0"
+    "uxp-documentation": "github:adobedocs/uxp#v7.4.0"
   },
   "scripts": {
     "start": "gatsby build && gatsby serve",

--- a/src/pages/ps_reference/changelog/index.md
+++ b/src/pages/ps_reference/changelog/index.md
@@ -7,23 +7,25 @@ contributors:
 ---
 
 # Photoshop API Changelog
+## Photoshop Beta 25.10 (May 2024)
+`timeOut` option added to [`executeAsModal`](../media/executeasmodal/#options-parameter).  Also, the error message returned on a modal request collision was updated to include the id of the plugin that initiated the existing modal state.
 
 ## Photoshop Beta 25.5 (February 2024)
 
 ### UXP v7.4 Integration
+> #### Updated
+> - UXP Alerts ([alert](../../uxp-api/reference-js/Global%20Members/HTML%20DOM/alert.md), [prompt](../../uxp-api/reference-js/Global%20Members/HTML%20DOM/prompt.md), [confirm](../../uxp-api/reference-js/Global%20Members/HTML%20DOM/confirm.md)) have been moved back to beta due to a few inherent instabilities in this feature. While we work on addressing these issues, the feature can be accessed using the feature flag `enableAlerts` in the manifest.json file. Also, note that UXP alerts will be `available only in Plugins` and `not in scripts`.
+> - Wildcards (*) at the top-level `domain` name are not allowed. Please ensure you revisit the `permissions` setup in manifest.json for [WebView](../../uxp-api/reference-js/Global%20Members/HTML%20Elements/HTMLWebViewElement.md), and network calls ([XMLHttp](../../uxp-api/reference-js/Global%20Members/Data%20Transfers/XMLHttpRequest.md), [fetch](../../uxp-api/reference-js/Global%20Members/Data%20Transfers/fetch.md))
+> - New doc for tracking the [mapping between Spectrum widgets and Spectrum Web Components](../../uxp-api/reference-spectrum/spectrum-widgets-to-swc-mapping/index.md) in UXP
+> 
+> 
+> #### Fixed
+> - XMP now works in UXP Scripts.
+> - Plugin crashes while using [fit-content](https://forums.creativeclouddeveloper.com/t/ps-2024-crashes-when-opening-my-uxp-plugin/6840/7) 
+> - WebView support for [file selector](https://forums.creativeclouddeveloper.com/t/macos-uxp-webview-for-photoshop-is-missing-file-selector/6843) in MacOS
+> - GUID returning hashed empty string
+> - Updated missing docs for pseudo-class [defined](../../uxp-api/reference-css/Pseudo-classes/defined.md) (Available since UXP v6.0)
 
-#### Updated
-- UXP Alerts ([alert](../../uxp-api/reference-js/Global%20Members/HTML%20DOM/alert.md), [prompt](../../uxp-api/reference-js/Global%20Members/HTML%20DOM/prompt.md), [confirm](../../uxp-api/reference-js/Global%20Members/HTML%20DOM/confirm.md)) have been moved back to beta due to a few inherent instabilities in this feature. While we work on addressing these issues, the feature can be accessed using the feature flag `enableAlerts` in the manifest.json file. Also, note that UXP alerts will be `available only in Plugins` and `not in scripts`.
-- Wildcards (*) at the top-level `domain` name are not allowed. Please ensure you revisit the `permissions` setup in manifest.json for [WebView](../../uxp-api/reference-js/Global%20Members/HTML%20Elements/HTMLWebViewElement.md), and network calls ([XMLHttp](../../uxp-api/reference-js/Global%20Members/Data%20Transfers/XMLHttpRequest.md), [fetch](../../uxp-api/reference-js/Global%20Members/Data%20Transfers/fetch.md))
-- New doc for tracking the [mapping between Spectrum widgets and Spectrum Web Components](../../uxp-api/reference-spectrum/spectrum-widgets-to-swc-mapping/index.md) in UXP
-
-
-#### Fixed
-- XMP now works in UXP Scripts.
-- Plugin crashes while using [fit-content](https://forums.creativeclouddeveloper.com/t/ps-2024-crashes-when-opening-my-uxp-plugin/6840/7) 
-- WebView support for [file selector](https://forums.creativeclouddeveloper.com/t/macos-uxp-webview-for-photoshop-is-missing-file-selector/6843) in MacOS
-- GUID returning hashed empty string
-- Updated missing docs for pseudo-class [defined](../../uxp-api/reference-css/Pseudo-classes/defined.md) (Available since UXP v6.0)
 
 
 ## Photoshop Beta 25.2 (October 2023)
@@ -471,7 +473,7 @@ It is now possible to use the Photoshop Actions panel to help build your plugin.
 This event is generated when Photoshop detects that a user becomes idle, while Photoshop is the foreground application. A plugin must specify a number of idle seconds, and then may choose to batch process-intensive tasks. See [photoshopCore](../media/photoshopcore/).
 
 ### Interactive Mode for executeAsModal
-As an alterative to a UI-blocking progress bar when a plugin is within a Modal Execution scope, `interactiveMode` can be requested to allow for user interaction in specific circumstances. See [Interactive Mode](../media/executeasmodal#interactive-mode/).
+As an alternative to a UI-blocking progress bar when a plugin is within a Modal Execution scope, `interactiveMode` can be requested to allow for user interaction in specific circumstances. See [Interactive Mode](../media/executeasmodal/#interactive-mode).
 
 ----
 ## Photoshop 23.2 (February 2022)

--- a/src/pages/ps_reference/media/executeasmodal.md
+++ b/src/pages/ps_reference/media/executeasmodal.md
@@ -4,102 +4,127 @@ title: "ExecuteAsModal Details"
 sidebar_label: "Modal Execution"
 ---
 
-# ExecuteAsModal
+# Modal Execution in an Async World: executeAsModal
 
-ExecuteAsModal is needed when a plugin wants to make modifications to the Photoshop state. This includes scenarios where the plugin creates or modify documents, or the plugin wishes to update UI or preference state.
+Introduced with [apiVersion](../../../guides/uxp_guide/uxp-misc/manifest-v4/photoshop-manifest/#apiversion) 2, a modal state is required when a plugin wants to make modifications to the Photoshop state. This modal state prevents other operations from outside the plugin from interferring, potentially leading to an unstable application state.  Operations requiring a modal state include creating or modifying documents, or even updating UI or preference state.
 
-ExecuteAsModal is only available to a plugin that is using apiVersion 2 or higher.
+Since only one plugin at a time can use `executeAsModal`, exclusive access to Photoshop is guaranteed with respect to other plugins' calls to `executeAsModal`.
 
-Only one plugin at a time can use `executeAsModal`, and this means that executeAsModal guarantees that the plugin gets exclusive access to Photoshop.
+When `executeAsModal` is executed, Photoshop enters a modal user interaction state, affecting much of the UI. Note that some menu items are disabled. Again, this measure is also intended to prevent interference.
 
-When executeAsModal is active, then Photoshop enters a modal user interaction state. This means that some menu items are disabled.
-If the modal state lasts a significant amount of time (currently more than two seconds), then a progress bar is shown. The progress bar will identify the plugin that is associated with the modal state, and it will include the ability for the user to cancel the interaction. The following illustrates the progress bar that would be created for a plugin called "Sample Plugin". The progress bar is indefinite until the plugin informs Photoshop about its progress.
+<!-- Move this down to progress bar section? -->
+If the modal state lasts a significant amount of time (currently more than two seconds), then a progress bar will appear. The progress dialog's title bar will display the name of the plugin that initiated the modal state, and it will include the ability for the user to cancel the interaction. The following illustrates the progress bar that would be shown for a plugin labled "Sample Plugin". The message that appears above the bar is supplied by `commandName` as described under [Arguments](#arguments). The progress bar will show indefinite progress until the plugin informs Photoshop about its quantative progress.
 
 ![progress bar](./assets/progress-bar.png)
+<!-- p b -->
 
 When a plugin is inside a modal scope, then it controls Photoshop. This means that you no longer need to use options such as `modalBehavior` with `batchPlay`.
 
 <br />
 
-## API
 
-ExecuteAsModal is exposed on the Photoshop core module.
+`executeAsModal` is exposed on the Photoshop UXP API [core module](./photoshopcore).
 
 ```javascript
-require('photoshop').core.executeAsModal(targetFunction, options);
+await require('photoshop').core.executeAsModal(targetFunction, options);
 ```
-targetFunction is a JavaScript function that will be executed after Photoshop enters a modal state. When the targetFunction completes, then Photoshop will exit the modal state. The targetFunction can be asynchronous.
 
-Only one plugin can be modal at any given time. If another plugin is modal when you call executeAsModal, then executeAsModal will raise an error. It is therefore important to handle errors when calling this method.
+## Arguments
 
-It is also recommended that JavaScript awaits on the result from executeAsModal. Without an await, JavaScript will proceed to the subsequent lines of code while Photoshop enters a modal state.
+1. *targetFunction*: The JavaScript function to execute after Photoshop enters a modal state.
+1. *options*: An object literal describing [the options for the request](#options-parameter). 
+
+### Target Function parameter
+The `targetFunction` parameter is a JavaScript function that will be executed after Photoshop enters the requested modal state. When the `targetFunction` completes, then Photoshop will exit the modal state. It can be asynchronous, but care should be give to ensure it does not return early. It has the following signature:
+```javascript
+async function targetFunction(executionContext, descriptor)
+```
+
+The *executionContext* parameter contains functionality related to managing the modal state. It contains the following properties:
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| isCancelled | boolean | True if the user has cancelled the modal interaction. |
+| onCancel | function | If function is assigned to this property, then this function is executed if the user cancels the modal interaction. |
+| reportProgress | function | A function that can customize updates to the progress bar. See [progress bar](#progress-bar) below for details. |
+| hostControl | object | An object literal containing the following properties: |
+
+   * `suspendHistory`: A function that can be used to suspend history on a target document. See [History state suspension](#history-state-suspension).
+   * `resumeHistory`: A function that can be used to resume history on a target document. See [History state suspension](#history-state-suspension).
+   * `registerAutoCloseDocument`: Register a document to be closed when the modal scope exits. See [Automatic document closing](#automatic-document-closing).
+   * `unregisterAutoCloseDocument`: Unregister a document from being closed when the modal scope exits. See [Automatic document closing](#automatic-document-closing).
+  
+The *descriptor* contains the values provided to the descriptor property in the options argument to `executeAsModal`.  It is used to pass values to the function's scope.
+
+
+### Options parameter
+The options object can contain the following properties:
+
+| Name | Type | Inclusion | Min Version | Description |
+| :------ | :------ | :------ | :------ | :---------- |
+| commandName | string | **required** | 23.0 |  This description is shown above the progress bar. |
+| descriptor | object | optional | 23.0 | Command arguments are provided to the target function via this object. See documentation for [*targetFunction*](#target-function-parameter) below. |
+| interactive | boolean | optional | 23.0 | A boolean to toggle [interactive mode](#interactive-mode).  |
+| timeOut | number | optional | 25.10 | Defaults to one second. During this time, the request will enter a queue to attempt again.  The attempts will continue until the blocking modal state concludes or time expires. |
+
+Since only one plugin can be modal at any given time, what happens if another plugin is modal when you call `executeAsModal`?  Previously, `executeAsModal` would immediately throw an error, declaring, *"host is in a modal state"*. Starting in 25.10, the request will continue to try until the the specified duration is exhausted.  That duration defaults to one second and is controlled by the `timeOut` option.  Most modal interactions are expected to be very short. Even with the timeout, it remains important to handle errors when calling this method.
+
+Also new in 25.10, the error message returned due to an existing modal state will include the plugin that held that existing state.  For example, *"Plugin: com.adobe.testPlugin is running a modal command"*. This identification will assist with debugging modal state collisions.  
+- If it's your plugin, then you likely didn't use `await`.
+- If it's another third-party plugin, you can disable that during your development.
+- If it's an Adobe plugin, [please let us know in the forum](https://forums.creativeclouddeveloper.com/c/photoshop/63).
+
+We highly recommend that the use of `await` with with calls to `executeAsModal`. Without an await, execution will proceed to the subsequent lines of code while Photoshop enters the requested modal state.
 
 A typical use case is:
 ```javascript
 try {
-    await require('photoshop').core.executeAsModal(targetFunction, {"commandName": "My Script Command"});
-    }
-    catch(e) {
-      if (e.number == 9) {
-          showAlert("executeAsModal was rejected (some other plugin is currently inside a modal scope)");
-      }
-      else {
-        // This case is hit if the targetFunction throws an exception
-      }
-    }
+  await require('photoshop').core.executeAsModal(
+    targetFunction,
+    {commandName: "My Script Command"}
+  );
+} catch(e) {
+  if (e.number == 9) {
+    console.error(e);
+    showAlert("executeAsModal was rejected (some other plugin is currently inside a modal scope)");
+  } else {
+    // This case is hit if the targetFunction throws an exception.
+  }
+}
 ```
 
 <br />
 
-### Arguments
-executeAsModal takes the following arguments:
-1. targetFunction: The JavaScript function to execute after Photoshop enters a modal state.
-1. options: Options describing the request. The following properties are recognized:
-    1. commandName (required): A string describing the command. This string is shown in the progress bar UI.
-    1. descriptor (optional): An object with command arguments. See documentation for targetFunction below.
-    1. interactive (optional): A boolean to toggle [interactive mode](#interactive-mode). 
-
-The JavaScript target function has the following signature:
-```javascript
-async function targetFunction(executionContext, descriptor)
-```
-The executionContext contains functionality related to managing the modal state.
-
-The descriptor contains the values provided to the descriptor property in the options argument to executeAsModal.
-
-The executionContext contains the following properties:
-* isCancelled: A boolean that is true if the user has cancelled the modal interaction.
-* onCancel: A function property. If JavaScript assigns a function to this property, then this function is executed if the user cancels the modal interaction.
-* reportProgress: A function that JavaScript can use to customize the progress bar. See below for details.
-* hostControl: An object containing the following properties:
-   * suspendHistory. A function that can be used to suspend history on a target document. See below for details.
-   * resumeHistory. A function that can be used to resume history on a target document. See below for details.
-   * registerAutoCloseDocument. Register a document to be closed when the modal scope exits. See below for details.
-* unregisterAutoCloseDocument. Unregister a document from being closed when the modal scope exits. See below for details.
-
-<br />
-
-### User cancellation
-executeAsModal puts Photoshop into a modal state, and it is important to allow the user to exit this state if the command was invoked by mistake, or if the command is taking too much time.
+## User cancellation
+`executeAsModal` puts Photoshop into a modal state, and it is important to allow the user to exit this state if the command was invoked by mistake, or if the command is taking too much time.
 
 The user can cancel the operation by pressing the Escape key or using cancellation UI in the progress bar.
 If the user cancels the interaction, then JavaScript should return from its target function as soon as possible.
-JavaScript can use `isCancelled` and `onCancel` on the executionContext to get information about the current user cancellation state. In addition to this, Photoshop APIs such as `batchPlay` will raise an exception if they are invoked from a target function after the user has cancelled the interaction.
+JavaScript can use `isCancelled` and `onCancel` on the *executionContext* to get information about the current user cancellation state. In addition to this, Photoshop APIs such as `batchPlay` will raise an exception if they are invoked from a target function after the user has cancelled the interaction.
 
 The following is an example of a target JavaScript function:
 ```javascript
 async function targetFunction(executionContext, descriptor) {
-  let target = {_ref:[{_ref:"property", "_property": "hostName"}, {"_ref":"application","_enum":"ordinal","_value":"targetEnum"}]};
-  let command = {"_obj": "get", "_target": target};
-  while (true) {
+  let target = {
+    _ref: [
+      {_ref: "property", _property: "hostName"},
+      {_ref: "application", _enum: "ordinal", _value: "targetEnum"}
+    ]
+  };
+  let command = {_obj: "get", _target: target};
+  while(true) { // <--  HERE WE WAIT FOR THE USER TO MANUALLY CANCEL
     await psAction.batchPlay([command], {});
   }
 }
-await require("photoshop").core.executeAsModal(targetFunction, {"commandName": "User Cancel Test"});
-```
-This sample will run until the user cancels the interaction. After the user cancels, the modal scope becomes cancelled, and the next call to batchPlay will raise an exception and exit the target function.
 
-Due to the design of the underlying JavaScript runtime, JavaScript can only be cancelled when it is *interruptible*. JavaScript can be interrupted when it is waiting on the resolution of a promise. Without the "await" keyword in the above example, the JavaScript function would not terminate when the user cancels. Having a tight loop such as the following also does not allow for automatic cancellation of the JavaScript function.
+await require("photoshop").core.executeAsModal(
+  targetFunction,
+  {commandName: "User Cancel Test"}
+);
+```
+Due to the `while` loop, this sample will run until the user cancels the interaction. After the user cancels, the modal scope becomes cancelled, and the next call to batchPlay will raise an exception and exit the target function.
+
+Due to the design of the underlying JavaScript runtime, JavaScript can only be cancelled when it is *interruptible*. JavaScript can be interrupted when it is waiting on the resolution of a promise. Without the `await` keyword in the above example, the JavaScript function would not terminate when the user cancels. Having a tight loop such as the following also does not allow for automatic cancellation of the JavaScript function.
 ```javascript
 async function targetFunction(executionContext) {
   while (true) {
@@ -107,7 +132,7 @@ async function targetFunction(executionContext) {
   }
 }
 ```
-JavaScript that runs for a significant amount of time without an interruption point should regularly query isCancelled on the executionContext. The JavaScript example above can be made cancellable by modifying it to the following:
+JavaScript that runs for a significant amount of time without an interruption point should regularly query `isCancelled` on the *executionContext*. The JavaScript example above can be made cancellable by modifying it to the following:
 ```javascript
 async function targetFunction(executionContext) {
   while (true) {
@@ -118,62 +143,73 @@ async function targetFunction(executionContext) {
   }
 }
 ```
-When the JavaScript function uses "await" with a Photoshop JavaScript command, then it is automatically terminated if the user cancels the operation. The automatic cancellation relies on JavaScript exceptions, and it is therefore important to not discard exceptions. The following function discards exceptions around batchPlay and will therefore *not* be automatically terminated when the user cancels the interaction.
+
+When the JavaScript function uses `await` with a Photoshop JavaScript command, then it is automatically terminated if the user cancels the operation. The automatic cancellation relies on JavaScript exceptions, and it is therefore important to not discard exceptions. The following function discards exceptions around the `batchPlay` call and will therefore *not* be automatically terminated when the user cancels the interaction.
 ```javascript
 async function targetFunction(executionContext) {
-  let target = {_ref:[{_ref:"property", "_property": "hostName"}, {"_ref":"application","_enum":"ordinal","_value":"targetEnum"}]};
-  let command = {"_obj": "get", "_target": target};
-  while (true) {
+  let target = {_ref: [
+    {_ref: "property", _property: "hostName"},
+    {_ref: "application", _enum: "ordinal", _value: "targetEnum"}
+  ]};
+  let command = {_obj: "get", _target: target};
+
+  while (true) { // <--  HERE WE WAIT FOR THE USER TO MANUALLY CANCEL
     try {
        await psAction.batchPlay([command], {});
-    } catch (e) {}
+    } catch (e) {}  // WILL NOT AUTOMATICALLY TERMINATE ON CANCEL
   }
 }
-await require("photoshop").core.executeAsModal(targetFunction, {"commandName": "User Cancel Test"});
+
+await require("photoshop").core.executeAsModal(targetFunction, {commandName: "User Cancel Test"});
 ```
 
 <br />
 
-### Progress bar
+## Progress bar
 By default, Photoshop shows an indeterminate progress bar while a modal scope is active. The progress bar is shown a few seconds after the modal scope is initiated.
-JavaScript can use `reportProgress` to customize this behavior. To obtain a determinate progress bar, JavaScript can specify a value between 0 and 1 when calling reportProgress. Example:
+In JavaScript we can use the execution context's method `reportProgress` to customize the progress reporting. To obtain a determinate progress bar, JavaScript can specify a value between 0 and 1 when calling reportProgress. For example:
 ```javascript
 async function targetFunction(executionContext) {
-  executionContext.reportProgress({"value": 0.3});
+  executionContext.reportProgress({value: 0.3});
 }
 ```
+
 Setting a value will switch the progress bar to be a determinate progress bar & show the progress bar if it is not yet visible.
 
-JavaScript can change the commandName that is shown in the progress UI by using the "commandName" property. This can be used to inform the user about the current stage of the operation. Example:
+JavaScript can change the message that is shown in the progress UI by using the `commandName` property. This can be used to inform the user about the current stage of the operation. Example:
 ```javascript
-executionContext.reportProgress({"value": 0.9, "commandName": "Finishing Up"});
+executionContext.reportProgress({value: 0.9, commandName: "Finishing Up"});
 ```
 ![progress bar](./assets/progress-bar-2.png)
 
-The progress bar is hidden while modal UI is shown.
+The progress bar is hidden while modal UI is shown.  
+<!-- Also, the progress bar may be suppressed using the option `suppressProgressBar` in `batchPlay` [options](./batchplay.md#command-execution-options). -->
 
 <br />
 
-### Interactive Mode
+## Interactive Mode
 *Added in Photoshop 23.3*
 
-If a plugin requires the accepting of user input or interaction while in a executeAsModal scope, "Interactive Mode" may be required.
+If a plugin requires the accepting of user input or interaction while in an `executeAsModal` scope, "Interactive Mode" may be required.
 
 This mode refrains from displaying a blocking progress dialog to the user, and reduces the number of restrictions that hinder accepting of user input. Use-cases for interactive mode may include:
 - allowing users to input data into an invoked modal filter dialog
 - awaiting user input on a Photoshop workspace, such as Select and Mask
 
 ```javascript
-await require("photoshop").core.executeAsModal(targetFunction, {"commandName": "Apply two filters", "interactive": true});
+await require("photoshop").core.executeAsModal(
+  targetFunction,
+  {commandName: "Apply two filters", interactive: true}
+  );
 ```
 
-In lieu of the progress bar dialog, users can find the `Cancel Plugin Command` menu item under the Photoshop `Plugins` menu. This will interrupt the plugin's executeAsModal scope as described in [User Cancellation](#user-cancellation).
+In lieu of the progress bar dialog, users can find the `Cancel Plugin Command` menu item under the Photoshop `Plugins` menu. This will interrupt the plugin's `executeAsModal` scope as described in [User Cancellation](#user-cancellation).
 
 ![cancel via plugin menu](./assets/eam-pluginmenu-cancel.png)
 
 <br />
 
-### History state suspension
+## History state suspension
 The hostControl property on the executionContext can be used to suspend and resume history states. While a history state is suspended, Photoshop will coalesce all document changes into a single history state with a custom name.
 
 Example:
@@ -185,11 +221,11 @@ async function historyStateSample(executionContext) {
     let documentID = await getTargetDocument();
 
     // Suspend history state on the target document
-    // This will coalesce all changes into a single history state called
+    // This will collect all changes into a single history state called
     // 'Custom Command'
     let suspensionID = await hostControl.suspendHistory({
-        "documentID": documentID,
-        "name": "Custom Command"
+        documentID: documentID,
+        name: "Custom Command"
     });
 
     // modify the document
@@ -203,25 +239,30 @@ The signature for suspendHistory is:
 ```javascript
 executionContext.hostControl.suspendHistory(options)
 ```
-The `options` argument is an object with the following properties:
-* `documentID: number`: The ID of the document whose history state should be suspended.
-* `name: string`: The name that is used for the history state. This is visible in the History panel.
-suspendHistory returns a suspension identifier. This identifier should be used with resumeHistory.
+The `options` parameter is an object with the following properties:
+| Name | Type | Description |
+| :--------- | :------ | :---------- |
+| documentID | number | The ID of the document whose history state should be suspended. |
+| name | string | This name will be shown on the history state in the History panel. `suspendHistory` returns a suspension identifier. This identifier should be used with `resumeHistory`. |
 
-The signature for resumeHistory is:
+The signature for `resumeHistory` is:
 ```javascript
 executionContext.hostControl.resumeHistory(suspensionID, commit)
 ```
-* `suspensionID: object`: the suspension identifier object that was returned from `suspendHistory`.
-  * To rename the committed history state, assign an optional `finalName: string` to this parameter in order to provide an updated history state naming to be displayed to the user, overriding the original `name` passed in with `suspendHistory`.
-* `commit: boolean`: if `true` then the current document state is committed and a history state is created. If `false`, the document state is rolled back to the time when the state was suspended. This argument is optional and the default value is `true`. Photoshop only creates a history state if the document was modified between the calls to `suspendHistory` and `resumeHistory`.
+1. `suspensionID: object`: The suspension identifier object that was returned from `suspendHistory`.
+    * To rename the committed history state, assign an optional string to the property `finalName` on this object to provide a final update to the name of the history state in the History panel. This will override the original `name` passed to `suspendHistory`.
+2. `commit: boolean`: If `true`, then the current document state is committed, and a history state is created. If `false`, the document state is rolled back to the time when the state was suspended. This argument is optional and the default value is `true`. Note that Photoshop only creates a history state if the document was modified between the calls to `suspendHistory` and `resumeHistory`.
 
 When the modal scope ends, Photoshop will auto-resume history on any document that is still in a suspended state. If the target function for the modal scope returns normally, then all unsuspended states are committed. If the target function exits via an exception, then all unsuspended history states are cancelled.
 
+<!--  Prerelease still
+When a user plays an Action from the Actions panel, they have the option to suspend the history state on the active document for the duration of the playback. If a UXP plugin calls `suspendHistory` in this situation, the call to `suspendHistory` is ignored, and the following value is returned: `4294967295` (0xFFFFFFFF). This value indicates that the currently running Action owns the document suspension state. If a plugin invokes `resumeHistory` with a commit value of `true` and suspension ID of 4294967295, then an exception will be raised. A plugin cannot roll back changes for a suspension state that is owned by the Actions panel.
+-->
+
 <br />
 
-### Notifications
-When executeAsModal is active, then Photoshop notifications are silenced similar to when an action is run from the actions panel.
+## Event Notifications
+When `executeAsModal` is active, then Photoshop event notifications are silenced similar to when an action is run from the actions panel.
 
 This means that other plugins cannot listen for batchPlay commands that are executed while the modal scope is active.
 
@@ -231,7 +272,7 @@ Plugins can register for notifications related to starting and ending a modal Ja
 
 <br />
 
-### Automatic document closing
+## Automatic document closing
 When the user cancels a modal scope, then JavaScript cannot make any further document changes until it returns from the modal scope. In order to ensure proper clean up of temporary documents, JavaScript can register one or more documents to be automatically closed without saving when the modal scope ends. The following is an example of JavaScript that registers a document to be closed when the modal scope ends:
 ```javascript
 async function modalFunction(executionContext) {
@@ -243,7 +284,7 @@ async function modalFunction(executionContext) {
     ...
 }
 ```
-JavaScript can unregister a document from being automatically closed by using unregisterAutoCloseDocument. The following illustrates JavaScript that creates and marks a document as "auto close" while the method is running. If the method succeeds then the document is unregistered from the set of auto close documents. This allows JavaScript to create a complete document, or close the document is the user cancels while the script is running.
+JavaScript can unregister a document from being automatically closed by using `unregisterAutoCloseDocument`. The following illustrates JavaScript that creates and marks a document as "auto close" while the method is running. If the method succeeds then the document is unregistered from the set of auto close documents. This allows JavaScript to create a complete document, or close the document is the user cancels while the script is running.
 ```javascript
 async function modalFunction(executionContext) {
     let hostControl = executionContext.hostControl;
@@ -251,7 +292,7 @@ async function modalFunction(executionContext) {
     let docID = await createDocument();
     await hostControl.registerAutoCloseDocument(docID);
 
-    // Add contents to docID
+    // Add contents to the created document.
 
     ...
 
@@ -261,6 +302,6 @@ async function modalFunction(executionContext) {
 
 <br />
 
-### Notes
-You can have nested modal scopes. A target function can use executeAsModal to execute another target function.
-All modal scopes share the same global modal state. This mean that any nested scope can modify the state on the (single) progress bar. Similarly, you can suspend the history state of a document in one scope, and resume the state in another.
+## Notes
+You can have nested modal scopes. A target function can itself call `executeAsModal` to execute another target function.
+All modal scopes share the same global modal state. This mean that any nested scope can modify the state on the shared progress bar. Similarly, you can suspend the history state of a document in one scope, and resume the state in another.

--- a/src/pages/ps_reference/media/imaging.md
+++ b/src/pages/ps_reference/media/imaging.md
@@ -118,10 +118,12 @@ const pixelData = await imageObj.imageData.getData()
 ```
 
 #### `dispose`
-Calling this synchronous method will release the contained image data. Doing so will reduce memory usage faster then waiting for the JavaScript garbage collector to run.
+Calling this synchronous method will release the contained image data. Doing so will reduce memory usage faster than waiting for the JavaScript garbage collector to run.
 
 ```javascript
-pixelData.dispose();
+const imageData = await imaging.createImageDataFromBuffer( arrayBuffer, options );
+// perhaps a putPixels call
+imageData.dispose();
 ```
 
 

--- a/src/pages/ps_reference/objects/returnobjects/executeasmodaloptions.md
+++ b/src/pages/ps_reference/objects/returnobjects/executeasmodaloptions.md
@@ -23,3 +23,4 @@ keywords:
 | commandName | *string* | 22.5 | Name of the command. It will be shown in the progress bar if the operation takes a noticeable amount of time. |
 | descriptor | *object* | 22.5 | An object literal that is passed as the second parameter of &#x60;targetFunction&#x60; following an [executeAsModal](../executeasmodal) call. Cannot include functions. |
 | interactive | *boolean* | 23.3 | Optional mode where UI interactions are permissible within the executeAsModal state. Useful for allowing users to input data into invoked dialogs or workspaces. See [Modal Execution](../executeasmodal). |
+| timeOut | *number* | 25.10 | If an existing modal state is encountered at execution, this request will retry until this duration of seconds has passed. |

--- a/yarn.lock
+++ b/yarn.lock
@@ -20694,9 +20694,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uxp-documentation@git://github.com/adobedocs/uxp#v7.4.0":
+"uxp-documentation@github:adobedocs/uxp#v7.4.0":
   version: 7.4.0
-  resolution: "uxp-documentation@git://github.com/adobedocs/uxp#commit=36e0c9610c429d6d47b121f0a9143fc0e5e15bf9"
+  resolution: "uxp-documentation@https://github.com/adobedocs/uxp.git#commit=36e0c9610c429d6d47b121f0a9143fc0e5e15bf9"
   checksum: 45ce967c0ce1c64bb919eed8e67b862607332b3abc3a6f7cbb64f7378b7042f8af8b29cd540c8133a2df54ac3119dc175fbbb7cb85a78c8dab3657bcc0e80507
   languageName: node
   linkType: hard
@@ -20712,7 +20712,7 @@ __metadata:
     react-dom: ^17.0.2
     remark-cli: ^11.0.0
     remark-validate-links: ^12.1.0
-    uxp-documentation: "git://github.com/adobedocs/uxp#v7.4.0"
+    uxp-documentation: "github:adobedocs/uxp#v7.4.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION

## Description

We recently added/exposed the timeOut option for executeAsModal to help with modal request collisions. Also, we updated the error message to include the id of the plugin that held the modal state at the time of collision.

While I was there, I did some other editing and polishing of the executeasmodal page.

