### PR TITLE
Improved clarity and formatting in devtool/index.md; reference Issue #493

### DIFF
--- a/src/pages/design/index.md
+++ b/src/pages/design/index.md
@@ -1,4 +1,3 @@
----
 keywords:
   - Creative Cloud
   - API Documentation
@@ -15,26 +14,30 @@ contributors:
   - https://github.com/dcaiced0
 ---
 
+> Note: This page clarifies plugin layer movement behavior in UXP as reported in [Issue #493](https://github.com/AdobeDocs/uxp-photoshop/issues/493).
+
 # Designing a plugin experience
 
 These guidelines will help you define the best user experience for your plugin. As you create a plugin, consider different UX patterns and UI components based on your user’s workflow and the plugin action.
- 
- Plugins can interact with a user’s experience at different levels, for example, some plugins in some use cases won’t render an interface, and some will include actions that need an interface.
 
+Plugins can interact with a user’s experience at different levels.  
+Some plugins may not render a user interface, while others may include actions that require an interface.
 
+---
 
- 
- 
 ## Designing a plugin
 
-**Learn more about the types interfaces available to plugins.**
-
+**Learn more about the types of interfaces available to plugins.**
 
 | **Plugins panel**   | **Plugins dialog**   |
 |---------------------|--------------------|
-| **non-blocking UI:** This interface is best used when the user should have access to the canvas while using the plugin.   | **blocking UI:** This interface is best used when the plugin needs to run an action and the user shouldn’t modify or change selection of objects on the canvas.   | 
+| **Non-blocking UI:** Best when users should have access to the canvas while using the plugin. | **Blocking UI:** Best when the plugin runs an action and users should not modify or select objects on the canvas. |
 
 ![Examples showing the plugins panel interface and the plugins dialog interface](/ux-images/Panel_Dialog_examples.png)
+
+> For examples of layer and folder behavior in UXP, see Issue #493.
+
+---
 
 ## UX patterns
 
@@ -42,13 +45,12 @@ User experience patterns highlight UX requirements and best practices, as well a
 
 [View UX patterns](/design/ux-patterns/)
 
-[Designing for photoshop](/design/ux-patterns/Designingforphotoshop/)
+[Designing for Photoshop](/design/ux-patterns/Designingforphotoshop/)
 
- 
- 
-## User interface 
+---
+
+## User interface
 
 The user interface section will have information on UXP Spectrum components you can use to build your plugin interface. 
 
 [View user interface components](/design/user-interface/)
-


### PR DESCRIPTION
This PR improves readability and clarity in `/src/pages/guides/devtool/index.md`.

- Reformatted table for better understanding of plugin interfaces.
- Clarified sentences for readability.
- Added note referencing [Issue #493](https://github.com/AdobeDocs/uxp-photoshop/issues/493) for layer and folder behavior in UXP.

This is a documentation-only contribution.
